### PR TITLE
Fix double null-terminator byte in export names

### DIFF
--- a/src/rplexportgen/rplexportgen.cpp
+++ b/src/rplexportgen/rplexportgen.cpp
@@ -80,7 +80,6 @@ writeExports(std::ofstream &out,
    // Write out the strings
    for (const auto &name : exports) {
       out << ".string \"" << name << "\"" << std::endl;
-      out << ".byte 0" << std::endl;
       nameOffset += name.size() + 1;
    }
    out << std::endl;


### PR DESCRIPTION
Currently rplexportgen adds an extra .byte 0 after the already null-terminated export name. This causes the name offsets to mismatch from the ones encoded in the export table. Only the first export would be valid.