### PR TITLE
elf2rpl: Match load section alignment with official RPLs

### DIFF
--- a/src/elf2rpl/main.cpp
+++ b/src/elf2rpl/main.cpp
@@ -191,7 +191,7 @@ generateFileInfoSection(ElfFile &file,
    info.dataSize = 0u;
    info.dataAlign = 4096u;
    info.loadSize = 0u;
-   info.loadAlign = 4u;
+   info.loadAlign = 32u;
    info.tempSize = 0u;
    info.trampAdjust = 0u;
    info.trampAddition = 0u;


### PR DESCRIPTION
## Description
This simply changes the alignment of the load region, something which are found to be 0x20 in official RPLs from various officially compiled RPLs. Elf2rpl currently aligns some segments with 0x04.

This was encountered when producing an RPL with multiple exports, which causes an error when loading the .fsegments (the exports segment) upon loading on the Wii U (you can also [see the error check](https://github.com/decaf-emu/decaf-emu/blob/6feb1be1db3938e6da2d4a65fc0a7a8599fc8dd6/src/libdecaf/src/cafe/loader/cafe_loader_setup.cpp#L321-L329) in Decaf's 1:1 reimplementation of the RPL loader) due to that segment not being aligned to 0x20.

Below is the output for each of the RPLs, which if you want to do some math shows you that it was previously misaligned and now is aligned with this change.

<details>
<summary>readrpl output of broken RPL</summary>


```
ElfHeader
  magic                = 0x7F454C46
  fileClass            = 1
  encoding             = 2
  elfVersion           = 1
  abi                  = EABI_CAFE 0xcafe
  type                 = 65025 0xFE01
  machine              = EM_PPC 20
  version              = 0x1
  entry                = 0x02000000
  phoff                = 0x0
  shoff                = 0x40
  flags                = 0x0
  ehsize               = 52
  phentsize            = 0
  phnum                = 0
  shentsize            = 40
  shnum                = 23
  shstrndx             = 20
Sections:
  [Nr] Name                 Type             Addr     Off    Size   ES Flag Lk Info Align
  [ 0]                      SHT_NULL         00000000 000000 000000 00       0    0     0
  [ 1] .text                SHT_PROGBITS     02000000 0CE714 1FE953 00  AXZ  0    0     4
  [ 2] .rela.text           SHT_RELA         00000000 2CD067 06EA05 0C    Z 18    1     4
  [ 3] .rodata              SHT_PROGBITS     10000000 0004BC 05E283 00  WAZ  0    0    16
  [ 4] .rela.rodata         SHT_RELA         00000000 33BA6C 05458C 0C    Z 18    3     4
  [ 5] .eh_frame            SHT_PROGBITS     10339FD8 05E73F 03636B 00  WAZ  0    0     4
  [ 6] .rela.eh_frame       SHT_RELA         00000000 38FFF8 01DA85 0C    Z 18    5     4
  [ 7] .data                SHT_PROGBITS     103C9B20 094AAA 000CC3 00  WAZ  0    0     8
  [ 8] .rela.data           SHT_RELA         00000000 3ADA7D 000B5E 0C    Z 18    7     4
  [ 9] .bss                 SHT_NOBITS       103CD8C0 000000 18BC1C 00   WA  0    0    16
  [10] .wut_load_bounds     SHT_PROGBITS     C0000000 09576D 000004 00    A  0    0     1
  [11] .fexports            SHT_RPL_EXPORTS  C0000020 095771 00005F 00  AXZ  0    0    16
  [12] .rela.fexports       SHT_RELA         00000000 3AE5DB 00002B 0C    Z 18   11     4
  [13] .fimport_coreinit    SHT_RPL_IMPORTS  C00000A0 0CE68A 00001F 00  AXZ  0    0    16
  [14] .fimport_gx2         SHT_RPL_IMPORTS  C0000220 0CE6A9 000018 00  AXZ  0    0    16
  [15] .fimport_nn_ac       SHT_RPL_IMPORTS  C0000240 0CE6C1 00001A 00  AXZ  0    0    16
  [16] .fimport_nsysnet     SHT_RPL_IMPORTS  C0000270 0CE6DB 00001C 00  AXZ  0    0    16
  [17] .dimport_coreinit    SHT_RPL_IMPORTS  C00002B0 0CE6F7 00001D 00   AZ  0    0    16
  [18] .symtab              SHT_SYMTAB       C00002E0 0957D0 01BBFB 10   AZ 19 5748     4
  [19] .strtab              SHT_STRTAB       C0037F40 0B13CB 01D222 00   AZ  0    0     1
  [20] .shstrtab            SHT_STRTAB       C00B80AA 0CE5ED 00009D 00   AZ  0    0     1
  [21]                      SHT_RPL_CRCS     00000000 000400 00005C 04       0    0     4
  [22]                      SHT_RPL_FILEINFO 00000000 00045C 000060 00       0    0     4
Section 22: SHT_RPL_FILEINFO, , 96 bytes
  version              = 0xCAFE0402
  textSize             = 0x0046DA00
  textAlign            = 0x20
  dataSize             = 0x0055A000
  dataAlign            = 0x1000
  loadSize             = 0x000B81F8
  loadAlign            = 0x4
  tempSize             = 0x27EA3C
  trampAdjust          = 0x0
  trampAddition        = 0x0
  sdaBase              = 0x00000000
  sda2Base             = 0x00000000
  stackSize            = 0x00010000
  heapSize             = 0x00008000
  filename             = 0
  flags                = 0x0
  minSdkVersion        = 0x00005078
  compressionLevel     = 6
  fileInfoPad          = 0x0
  sdkVersion           = 0x5335
  sdkRevision          = 0x10D4B
  tlsModuleIndex       = 0x0
  tlsAlignShift        = 0x0
  runtimeFileInfoSize  = 0x0
```
</details>

<details>
<summary>readrpl output for official RPL</summary>


```
ElfHeader
  magic                = 0x7F454C46
  fileClass            = 1
  encoding             = 2
  elfVersion           = 1
  abi                  = EABI_CAFE 0xcafe
  type                 = 65025 0xFE01
  machine              = EM_PPC 20
  version              = 0x1
  entry                = 0x02480EAC
  phoff                = 0x0
  shoff                = 0x40
  flags                = 0x0
  ehsize               = 52
  phentsize            = 0
  phnum                = 0
  shentsize            = 40
  shnum                = 17
  shstrndx             = 14
Sections:
  [Nr] Name                 Type             Addr     Off    Size   ES Flag Lk Info Align
  [ 0]                      SHT_NULL         00000000 000000 000000 00       0    0     0
  [ 1] .text                SHT_PROGBITS     02000000 0E8200 0FF4C5 00  AXZ  0    0    32
  [ 2] .fexports            SHT_RPL_EXPORTS  C0000000 04A400 049F6F 00  AXZ  0    0    32
  [ 3] .dexports            SHT_RPL_EXPORTS  C01E7420 094380 00011E 00   AZ  0    0    32
  [ 4] .data                SHT_PROGBITS     10000000 000440 049F8E 00  WAZ  0    0    32
  [ 5] .bss                 SHT_NOBITS       100F75C0 000000 00E760 00   WA  0    0    64
  [ 6] .rela.fexports       SHT_RELA         00000000 1E7700 01F5E6 0C    Z 12    2    12
  [ 7] .rela.dexports       SHT_RELA         00000000 206D00 000085 0C    Z 12    3    12
  [ 8] .rela.text           SHT_RELA         00000000 206DC0 01DC12 0C    Z 12    1     4
  [ 9] .rela.data           SHT_RELA         00000000 224A00 00000C 0C      12    4     4
  [10] .fimport_coreinit    SHT_RPL_IMPORTS  C0400380 0944C0 00003A 00  AXZ  0    0     4
  [11] .dimport_coreinit    SHT_RPL_IMPORTS  C0402600 094500 00001F 00   AZ  0    0     4
  [12] .symtab              SHT_SYMTAB       C01E7600 094540 02A2BD 10   AZ 13 7808     4
  [13] .strtab              SHT_STRTAB       C024A020 0BE800 02994E 00   AZ  0    0     1
 Section 16: SHT_RPL_FILEINFO, , 251 bytes
  version              = 0xCAFE0402
  textSize             = 0x004810F0
  textAlign            = 0x20
  dataSize             = 0x00105D20
  dataAlign            = 0x40
  loadSize             = 0x00402730
  loadAlign            = 0x20
  tempSize             = 0xBF380
  trampAdjust          = 0x0
  trampAddition        = 0x2C
  sdaBase              = 0x00008000
  sda2Base             = 0x00008000
  stackSize            = 0x00010000
  heapSize             = 0x00008000
  filename             = C:\Users\Gamer\Desktop\MemeRunUpdate20\_AOT\mscorlib_dll.rpl
  flags                = 0x0
  minSdkVersion        = 0x00005078
  compressionLevel     = -1
  fileInfoPad          = 0xA0
  sdkVersion           = 0x520B
  sdkRevision          = 0xD897
  tlsModuleIndex       = 0x0
  tlsAlignShift        = 0x0
  runtimeFileInfoSize  = 0x0
  Tags:
    "BUILD_TYPE" = "NDEBUG"
```
</details>

<details>
<summary>readrpl output of fixed RPL</summary>


```
ElfHeader
  magic                = 0x7F454C46
  fileClass            = 1
  encoding             = 2
  elfVersion           = 1
  abi                  = EABI_CAFE 0xcafe
  type                 = 65025 0xFE01
  machine              = EM_PPC 20
  version              = 0x1
  entry                = 0x02000000
  phoff                = 0x0
  shoff                = 0x40
  flags                = 0x0
  ehsize               = 52
  phentsize            = 0
  phnum                = 0
  shentsize            = 40
  shnum                = 23
  shstrndx             = 20
Sections:
  [Nr] Name                 Type             Addr     Off    Size   ES Flag Lk Info Align
  [ 0]                      SHT_NULL         00000000 000000 000000 00       0    0     0
  [ 1] .text                SHT_PROGBITS     02000000 0CE714 1FE953 00  AXZ  0    0     4
  [ 2] .rela.text           SHT_RELA         00000000 2CD067 06EA05 0C    Z 18    1     4
  [ 3] .rodata              SHT_PROGBITS     10000000 0004BC 05E283 00  WAZ  0    0    16
  [ 4] .rela.rodata         SHT_RELA         00000000 33BA6C 05458C 0C    Z 18    3     4
  [ 5] .eh_frame            SHT_PROGBITS     10339FD8 05E73F 03636B 00  WAZ  0    0     4
  [ 6] .rela.eh_frame       SHT_RELA         00000000 38FFF8 01DA85 0C    Z 18    5     4
  [ 7] .data                SHT_PROGBITS     103C9B20 094AAA 000CC3 00  WAZ  0    0     8
  [ 8] .rela.data           SHT_RELA         00000000 3ADA7D 000B5E 0C    Z 18    7     4
  [ 9] .bss                 SHT_NOBITS       103CD8C0 000000 18BC1C 00   WA  0    0    16
  [10] .wut_load_bounds     SHT_PROGBITS     C0000000 09576D 000004 00    A  0    0     1
  [11] .fexports            SHT_RPL_EXPORTS  C0000020 095771 00005F 00  AXZ  0    0    16
  [12] .rela.fexports       SHT_RELA         00000000 3AE5DB 00002B 0C    Z 18   11     4
  [13] .fimport_coreinit    SHT_RPL_IMPORTS  C00000A0 0CE68A 00001F 00  AXZ  0    0    16
  [14] .fimport_gx2         SHT_RPL_IMPORTS  C0000220 0CE6A9 000018 00  AXZ  0    0    16
  [15] .fimport_nn_ac       SHT_RPL_IMPORTS  C0000240 0CE6C1 00001A 00  AXZ  0    0    16
  [16] .fimport_nsysnet     SHT_RPL_IMPORTS  C0000270 0CE6DB 00001C 00  AXZ  0    0    16
  [17] .dimport_coreinit    SHT_RPL_IMPORTS  C00002B0 0CE6F7 00001D 00   AZ  0    0    16
  [18] .symtab              SHT_SYMTAB       C00002E0 0957D0 01BBFB 10   AZ 19 5748     4
  [19] .strtab              SHT_STRTAB       C0037F40 0B13CB 01D222 00   AZ  0    0     1
  [20] .shstrtab            SHT_STRTAB       C00B80AA 0CE5ED 00009D 00   AZ  0    0     1
  [21]                      SHT_RPL_CRCS     00000000 000400 00005C 04       0    0     4
  [22]                      SHT_RPL_FILEINFO 00000000 00045C 000060 00       0    0     4
Section 22: SHT_RPL_FILEINFO, , 96 bytes
  version              = 0xCAFE0402
  textSize             = 0x0046DA00
  textAlign            = 0x20
  dataSize             = 0x0055A000
  dataAlign            = 0x1000
  loadSize             = 0x000B8200
  loadAlign            = 0x20
  tempSize             = 0x27EA3C
  trampAdjust          = 0x0
  trampAddition        = 0x0
  sdaBase              = 0x00000000
  sda2Base             = 0x00000000
  stackSize            = 0x00010000
  heapSize             = 0x00008000
  filename             = 0
  flags                = 0x0
  minSdkVersion        = 0x00005078
  compressionLevel     = 6
  fileInfoPad          = 0x0
  sdkVersion           = 0x5335
  sdkRevision          = 0x10D4B
  tlsModuleIndex       = 0x0
  tlsAlignShift        = 0x0
  runtimeFileInfoSize  = 0x0
```
</details>