### PR TITLE
Elf2rpl: Fix order of sections inside the .rpx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         name: [
-          ubuntu-18.04
+          ubuntu-latest
         ]
         include:
-          - name: ubuntu-18.04
-            os: ubuntu-18.04
+          - name: ubuntu-latest
+            os: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v1

--- a/src/elf2rpl/main.cpp
+++ b/src/elf2rpl/main.cpp
@@ -764,35 +764,20 @@ calculateSectionOffsets(ElfFile &file)
    }
 
    // Next the "readMin / readMax" sections, which are:
-   // - !(flags & SHF_EXECINSTR) || type == SHT_RPL_EXPORTS
-   // - !(flags & SHF_WRITE)
+   // - type == SHT_RPL_EXPORTS || SHT_RPL_IMPORTS
+   // - !(flags & (SHF_EXECINSTR | SHF_WRITE))
    // - flags & SHF_ALLOC
-   for (auto &section : file.sections) {
-      if (section->header.size == 0 ||
-          section->header.type == elf::SHT_RPL_FILEINFO ||
-          section->header.type == elf::SHT_RPL_IMPORTS ||
-          section->header.type == elf::SHT_RPL_CRCS ||
-          section->header.type == elf::SHT_NOBITS) {
-         continue;
-      }
-
-      if ((!(section->header.flags & elf::SHF_EXECINSTR) ||
-             section->header.type == elf::SHT_RPL_EXPORTS) &&
-          !(section->header.flags & elf::SHF_WRITE) &&
-           (section->header.flags & elf::SHF_ALLOC)) {
-         section->header.offset = offset;
-         section->header.size = static_cast<uint32_t>(section->data.size());
-         offset += section->header.size;
-      }
-   }
-
-   // Import sections are part of the read sections, but have execinstr flag set
-   // so let's insert them here to avoid complicating the above logic.
-   for (auto &section : file.sections) {
-      if (section->header.type == elf::SHT_RPL_IMPORTS) {
-         section->header.offset = offset;
-         section->header.size = static_cast<uint32_t>(section->data.size());
-         offset += section->header.size;
+   // See: https://github.com/decaf-emu/decaf-emu/blob/e6c528a20a41c34e0f9eb91dd3da40f119db2dee/src/libdecaf/src/cafe/loader/cafe_loader_setup.cpp#L575
+   for (auto &section: file.sections) {
+      if (section->header.size > 0 &&
+          (section->header.flags & elf::SHF_ALLOC)) {
+         if (section->header.type == elf::SHT_RPL_EXPORTS ||
+             section->header.type == elf::SHT_RPL_IMPORTS ||
+             !(section->header.flags & (elf::SHF_EXECINSTR | elf::SHF_WRITE))) {
+            section->header.offset = offset;
+            section->header.size = static_cast<uint32_t>(section->data.size());
+            offset += section->header.size;
+         }
       }
    }
 

--- a/src/elf2rpl/main.cpp
+++ b/src/elf2rpl/main.cpp
@@ -717,6 +717,11 @@ calculateSectionOffsets(ElfFile &file)
    auto offset = file.header.shoff;
    offset += align_up(static_cast<uint32_t>((file.sections.size() - file.num_discarded_sections) * sizeof(elf::SectionHeader)), 64);
 
+   // Set all offsets to 0, so we can detect sections we didn't relocate
+   for (auto &section : file.sections) {
+      section->header.offset = 0u;
+   }
+
    for (auto &section : file.sections) {
       if (section->header.type == elf::SHT_NOBITS ||
           section->header.type == elf::SHT_NULL) {
@@ -825,7 +830,7 @@ calculateSectionOffsets(ElfFile &file)
       if (section->header.offset == 0 &&
           section->header.type != elf::SHT_NULL &&
           section->header.type != elf::SHT_NOBITS) {
-         fmt::print("Failed to calculate offset for section {}\n", section->index);
+         fmt::print("Failed to calculate offset for section {} ({})\n", section->name, section->index);
          return false;
       }
 


### PR DESCRIPTION
The CafeOS Loader loads .rpx files in chunks of 4MiB. Because of this, it's very important, that the sections of the .rpx are in a order the loader is expecting. Additionally the section offets inside the .rpx should only be in ascending order as is impossible to access the "previous" 4MiB chunk. Only binaries bigger than 4MiB even have a chance running into these, this why we never caught this earlier

But when compiling `fbalpha2012` retroarch core for Wii U, the `.symtab` section is still in the first 4MiB chunk (at 0x30D6C7), while the loader already loaded section from the second chunk (section 24, .dimport_coreinit at 0x43B67E).

This causes [this](https://github.com/decaf-emu/decaf-emu/blob/e6c528a20a41c34e0f9eb91dd3da40f119db2dee/src/libdecaf/src/cafe/loader/cafe_loader_setup.cpp#L137) check to fail in the loader: 

![grafik](https://github.com/devkitPro/wut-tools/assets/8582508/e7bb93c4-f1e8-496b-a6f5-90d9644a2b32)
![grafik](https://github.com/devkitPro/wut-tools/assets/8582508/5aa3126b-7f09-4340-93b9-5766652e7583)

The pull request tries to make sure the section are in the correct order. I don't really understand the logic for the LOADER section in current elf2rpl implemenation, but just [copy pasting the conditions the actual loader is checking](https://github.com/decaf-emu/decaf-emu/blob/e6c528a20a41c34e0f9eb91dd3da40f119db2dee/src/libdecaf/src/cafe/loader/cafe_loader_setup.cpp#L575) for seems to fix the order. Maybe the old elf2rpl implementation had to work around a broken/older wut.ld?

More tests are required but early results look promising. Here is a screenshot of a .elf converted to a .rpx with the patches of the PR. 
![grafik](https://github.com/devkitPro/wut-tools/assets/8582508/28ee9f9e-ff6b-4e0d-8544-f88f79dc97b2)
The binary is not even big enough to be loaded in multiple chunks, but the offsets of the sections are now correct.