### PR TITLE
wuhbtool: Allow a boot sound to be provided in btsnd format. Fixes #12

### DIFF
--- a/src/wuhbtool/main.cpp
+++ b/src/wuhbtool/main.cpp
@@ -62,6 +62,9 @@ int main(int argc, char **argv) {
                      value<std::string>{})
             .add_option("drc-image",
                description{"Splash Screen image shown on the DRC (854x480)"},
+               value<std::string>{})
+            .add_option("boot-sound",
+               description{"Boot sound played on TV and the DRC (btsnd format)"},
                value<std::string>{});
 
       parser.default_command()
@@ -154,6 +157,10 @@ int main(int argc, char **argv) {
    addImageResource(metaFolder, "iconTex.tga.gz",     128, 128, 32, options, "icon");
    addImageResource(metaFolder, "bootTvTex.tga.gz",  1280, 720, 24, options, "tv-image");
    addImageResource(metaFolder, "bootDrcTex.tga.gz",  854, 480, 24, options, "drc-image");
+	 
+   std::string bootSoundPath = options.get<std::string>("boot-sound");
+   auto bootSoundFile = OSFileEntry::fromPath(bootSoundPath.c_str(), "bootSound.btsnd");
+   metaFolder->addChild(bootSoundFile);
 
    addFolderIfNotEmpty(root, codeFolder);
    addFolderIfNotEmpty(root, metaFolder);


### PR DESCRIPTION
A small change to wuhbtool only to allow a custom file to be passed as a boot sound.

In order to work with the streamlined cmake targets provided by wut tools and use the env variable format, some dependant changes would be required in the wut repo.

https://github.com/devkitPro/wut/blob/958936de47c8765a770eeaee6d10e460cc02c28e/share/wut_rules#L55-L59

However, i'm unfamiliar with the toolchain and not sure how deep it goes.

Doesn't convert from wav, and no validation at this point.

Only example i can see in the wild of converting to the required format is [this repo](https://bitbucket.org/timogus/wav2btsnd/src/master/src/com/tim/wupsound/Starter.java) (working)

However, even it does not convert it into 16-bit 48Khz wav format required, so plenty to do to bring that into the toolchain, but its beyond my level of C.

Appreciate any feedback but more complex work will likely need help from others.

May be useful to note that current implementation of aroma homebrew_on_menu plugin limits the boot sound to only titles that have also provided a Tv and DRC splash image.

https://github.com/wiiu-env/homebrew_on_menu_plugin/blob/main/src/main.cpp#L565-L571